### PR TITLE
Fixed crash due to selection of deleted entry in other pane

### DIFF
--- a/src/browser/actions.c
+++ b/src/browser/actions.c
@@ -1305,6 +1305,8 @@ static void PerformShell(void)
 	free(marked_env);
 
 	VFS_RefreshAll();
+	B_DirectoryPaneReselect(active_pane);
+	B_DirectoryPaneReselect(other_pane);
 }
 
 const struct action open_shell_action = {

--- a/src/browser/actions.c
+++ b/src/browser/actions.c
@@ -798,6 +798,7 @@ static void PerformDeleteNoConfirm(void)
 	}
 	VFS_Refresh(dir);
 	B_DirectoryPaneReselect(active_pane);
+	B_DirectoryPaneReselect(other_pane);
 }
 
 const struct action delete_no_confirm_action = {


### PR DESCRIPTION
Description of the bug:
If the same directory and the same file entry are selected in both panes, then the file entry in one of the two panes is deleted, the file entry in the other pane is still selected, which leads to a crash.
WadGadget crashes in the browser/browser.c function DrawInfoPane() line 512 with a segmentation fault (Due to directory_entry *ent = NULL).

Fix for the bug:
In the browser/actions.c function PerformDeleteNoConfirm(), the call to the function B_DirectoryPaneReselect(other_pane) is added to prevent the deleted entry from continuing to be selected in the other pane.